### PR TITLE
Add Spring Boot backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+backend/target

--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Backend (Spring Boot)
+
+1. Go to the backend directory:
+   `cd backend`
+2. Run the tests:
+   `mvn test`
+3. Start the server:
+   `mvn spring-boot:run`
+4. Verify it's running at:
+   `http://localhost:8080/api/health`

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.4</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>mailing-backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>mailing-backend</name>
+    <description>Backend for mailing-masivo</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/mailing/BackendApplication.java
+++ b/backend/src/main/java/com/example/mailing/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.example.mailing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/mailing/controller/HealthController.java
+++ b/backend/src/main/java/com/example/mailing/controller/HealthController.java
@@ -1,0 +1,12 @@
+package com.example.mailing.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+    @GetMapping("/api/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/backend/src/test/java/com/example/mailing/BackendApplicationTests.java
+++ b/backend/src/test/java/com/example/mailing/BackendApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.mailing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot backend with health endpoint and basic test
- document backend usage and ignore build artifacts

## Testing
- `npm run build`
- `mvn test` (fails: Non-resolvable parent POM; network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a2358078b4832e9e2222917e85680a